### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/sqlite-store.js
+++ b/lib/sqlite-store.js
@@ -6,7 +6,7 @@
 var Sqlite = require('sqlite3')
 
 var _ = require('lodash')
-var Uuid = require('node-uuid')
+var Uuid = require('uuid')
 var error = require('eraro')({package: 'seneca-sqlite-store'})
 
 var name = 'sqlite-store'

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   "homepage": "https://github.com/senecajs-labs/seneca-sqlite-store",
   "bugs": "https://github.com/senecajs-labs/seneca-sqlite-store/issues",
   "dependencies": {
-    "sqlite3":    ">=2.1.5",
-    "node-uuid":  "*",
     "eraro": "^0.4.1",
-    "lodash": "^4.3.0"
+    "lodash": "^4.3.0",
+    "sqlite3": ">=2.1.5",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "lab": "8.2.x",
@@ -40,8 +40,7 @@
     "eslint-plugin-standard": "1.x.x",
     "eslint-plugin-hapi": "4.x.x"
   },
-
-  "files":[
+  "files": [
     "README.md",
     "LICENSE.txt",
     "lib/sqlite-store.js"


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.